### PR TITLE
PTHMINT-41: Fix error ANN003 occurences

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ extend-safe-fixes = [
     "D415", # docstrings should end with a period, question mark, or exclamation point
 ]
 ignore = [
-    "ANN003",
     "ANN101", # missing type annotation for self
     "ANN102", # missing type annotation for cls
     "ANN201",

--- a/src/multisafepay/api/base/listings/listing.py
+++ b/src/multisafepay/api/base/listings/listing.py
@@ -5,7 +5,7 @@
 
 # See the DISCLAIMER.md file for disclaimer details.
 
-from typing import Any, Generic, List, TypeVar
+from typing import Any, Dict, Generic, List, TypeVar
 
 from pydantic.main import BaseModel
 
@@ -24,7 +24,12 @@ class Listing(Generic[T], BaseModel):
 
     data: List[T]
 
-    def __init__(self, data: List[Any], class_type: type, **kwargs):
+    def __init__(
+        self,
+        data: List[Any],
+        class_type: type,
+        **kwargs: Dict[str, Any],
+    ):
         """
         Initialize the Listing with data and a class type.
 

--- a/src/multisafepay/api/base/response/custom_api_response.py
+++ b/src/multisafepay/api/base/response/custom_api_response.py
@@ -5,7 +5,7 @@
 
 # See the DISCLAIMER.md file for disclaimer details.
 
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from multisafepay.api.base.response.api_response import ApiResponse
 
@@ -22,14 +22,18 @@ class CustomApiResponse(ApiResponse):
 
     data: Optional[Any]
 
-    def __init__(self: "CustomApiResponse", data: Optional[Any], **kwargs):
+    def __init__(
+        self: "CustomApiResponse",
+        data: Optional[Any],
+        **kwargs: Dict[str, Any],
+    ):
         """
         Initialize the CustomApiResponse with optional data and additional keyword arguments.
 
         Parameters
         ----------
         data: (Any, optional) The data to be included in the response, by default None.
-        **kwargs: (dict) Additional keyword arguments to be set as attributes of the response.
+        **kwargs: Additional keyword arguments to be set as attributes of the response.
 
         """
         super().__init__(**kwargs)


### PR DESCRIPTION
This pull request includes updates to type annotations and configuration files to improve code clarity and maintainability. The most important changes involve refining type hints in constructors and updating the `pyproject.toml` file to adjust linting rules.

### Type annotation improvements:
* [`src/multisafepay/api/base/listings/listing.py`](diffhunk://#diff-62b5e588910b47a262dd56f3532f2992a0bdaafba9e9c02025e8cac0f9583451L27-R32): Updated the `__init__` method in the `Listing` class to use more precise type annotations, including `list[Any]` for the `data` parameter and `dict[str, Any]` for `**kwargs`.
* [`src/multisafepay/api/base/response/custom_api_response.py`](diffhunk://#diff-cc24ecd65384ecec7aebfe1a4fbedd71719b1653ea0448845cb8627689d39894L25-R25): Modified the `__init__` method in the `CustomApiResponse` class to include `dict[str, Any]` as the type for `**kwargs`.

### Configuration updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L101): Removed the `ANN003` rule from the `ignore` list, ensuring stricter adherence to type annotation guidelines.