### PR TITLE
PTHMINT-44: Remove code ANN102 from ruff ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ extend-safe-fixes = [
     "D415", # docstrings should end with a period, question mark, or exclamation point
 ]
 ignore = [
-    "ANN102", # missing type annotation for cls
     "ANN201",
     "ANN204",
     "ANN401",


### PR DESCRIPTION
This pull request includes a minor update to the `pyproject.toml` configuration file. The change removes the rule `ANN102` (missing type annotation for `cls`) from the `ignore` list, indicating that this rule will now be enforced.