### PR TITLE
PTHMINT-46: Fix ruff ANN204

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ extend-safe-fixes = [
     "D415", # docstrings should end with a period, question mark, or exclamation point
 ]
 ignore = [
-    "ANN204",
     "ANN401",
     "ARG002",
     "B006",

--- a/src/multisafepay/api/base/abstract_manager.py
+++ b/src/multisafepay/api/base/abstract_manager.py
@@ -19,7 +19,7 @@ class AbstractManager:
 
     """
 
-    def __init__(self: "AbstractManager", client: Client):
+    def __init__(self: "AbstractManager", client: Client) -> None:
         """
         Initialize the AbstractManager with a Client instance.
 

--- a/src/multisafepay/api/base/listings/listing.py
+++ b/src/multisafepay/api/base/listings/listing.py
@@ -5,7 +5,7 @@
 
 # See the DISCLAIMER.md file for disclaimer details.
 
-from typing import Any, Dict, Generic, List, TypeVar
+from typing import Any, Dict, Generic, Iterator, List, TypeVar
 
 from pydantic.main import BaseModel
 
@@ -29,7 +29,7 @@ class Listing(Generic[T], BaseModel):
         data: List[Any],
         class_type: type,
         **kwargs: Dict[str, Any],
-    ):
+    ) -> None:
         """
         Initialize the Listing with data and a class type.
 
@@ -53,7 +53,7 @@ class Listing(Generic[T], BaseModel):
 
         super().__init__(data=elements)
 
-    def __iter__(self: "Listing"):
+    def __iter__(self: "Listing") -> Iterator[T]:
         """
         Return an iterator over the items in the listing.
 
@@ -79,7 +79,7 @@ class Listing(Generic[T], BaseModel):
         """
         return self.data[index]
 
-    def __len__(self: "Listing"):
+    def __len__(self: "Listing") -> int:
         """
         Get the number of items in the listing.
 

--- a/src/multisafepay/api/base/listings/listing_pager.py
+++ b/src/multisafepay/api/base/listings/listing_pager.py
@@ -28,7 +28,7 @@ class ListingPager(Listing):
         data: list,
         pager: Optional[Pager],
         class_type: type,
-    ):
+    ) -> None:
         """
         Initialize the ListingPager with data, pager, and class type.
 

--- a/src/multisafepay/api/base/response/custom_api_response.py
+++ b/src/multisafepay/api/base/response/custom_api_response.py
@@ -26,7 +26,7 @@ class CustomApiResponse(ApiResponse):
         self: "CustomApiResponse",
         data: Optional[Any],
         **kwargs: Dict[str, Any],
-    ):
+    ) -> None:
         """
         Initialize the CustomApiResponse with optional data and additional keyword arguments.
 

--- a/src/multisafepay/api/paths/auth/auth_manager.py
+++ b/src/multisafepay/api/paths/auth/auth_manager.py
@@ -22,7 +22,7 @@ class AuthManager(AbstractManager):
     A manager class for handling authentication-related operations.
     """
 
-    def __init__(self: "AuthManager", client: Client):
+    def __init__(self: "AuthManager", client: Client) -> None:
         """
         Initialize the CaptureManager with a client.
 

--- a/src/multisafepay/api/paths/capture/capture_manager.py
+++ b/src/multisafepay/api/paths/capture/capture_manager.py
@@ -26,7 +26,7 @@ class CaptureManager(AbstractManager):
     A class to manage capture operations.
     """
 
-    def __init__(self: "CaptureManager", client: Client):
+    def __init__(self: "CaptureManager", client: Client) -> None:
         """
         Initialize the CaptureManager with a client.
 

--- a/src/multisafepay/api/paths/categories/category_manager.py
+++ b/src/multisafepay/api/paths/categories/category_manager.py
@@ -20,7 +20,7 @@ class CategoryManager(AbstractManager):
     A manager class for handling category-related API requests.
     """
 
-    def __init__(self: "CategoryManager", client: Client):
+    def __init__(self: "CategoryManager", client: Client) -> None:
         """
         Initialize the CategoryManager with a client.
 

--- a/src/multisafepay/api/paths/gateways/gateway_manager.py
+++ b/src/multisafepay/api/paths/gateways/gateway_manager.py
@@ -28,7 +28,7 @@ class GatewayManager(AbstractManager):
     Manages gateway-related operations.
     """
 
-    def __init__(self: "GatewayManager", client: Client):
+    def __init__(self: "GatewayManager", client: Client) -> None:
         """
         Initialize the CategoryManager with a client.
 

--- a/src/multisafepay/api/paths/issuers/issuer_manager.py
+++ b/src/multisafepay/api/paths/issuers/issuer_manager.py
@@ -24,7 +24,7 @@ class IssuerManager(AbstractManager):
     Manager class for handling issuer-related operations.
     """
 
-    def __init__(self: "IssuerManager", client: Client):
+    def __init__(self: "IssuerManager", client: Client) -> None:
         """
         Initialize the IssuerManager with a client.
 

--- a/src/multisafepay/api/paths/me/me_manager.py
+++ b/src/multisafepay/api/paths/me/me_manager.py
@@ -21,7 +21,7 @@ class MeManager(AbstractManager):
     A manager class for handling 'me' related API requests.
     """
 
-    def __init__(self: "MeManager", client: Client):
+    def __init__(self: "MeManager", client: Client) -> None:
         """
         Initialize the MeManager with a client.
 

--- a/src/multisafepay/api/paths/orders/order_manager.py
+++ b/src/multisafepay/api/paths/orders/order_manager.py
@@ -48,7 +48,7 @@ class OrderManager(AbstractManager):
     Manages operations related to orders, such as creating, updating, capturing, and refunding orders.
     """
 
-    def __init__(self: "OrderManager", client: Client):
+    def __init__(self: "OrderManager", client: Client) -> None:
         """
         Initialize the OrderManager with a client.
 

--- a/src/multisafepay/api/paths/payment_methods/payment_method_manager.py
+++ b/src/multisafepay/api/paths/payment_methods/payment_method_manager.py
@@ -30,7 +30,7 @@ class PaymentMethodManager(AbstractManager):
     A class representing the PaymentMethodManager.
     """
 
-    def __init__(self: "PaymentMethodManager", client: Client):
+    def __init__(self: "PaymentMethodManager", client: Client) -> None:
         """
         Initialize the CaptureManager with a client.
 

--- a/src/multisafepay/api/paths/recurring/recurring_manager.py
+++ b/src/multisafepay/api/paths/recurring/recurring_manager.py
@@ -35,7 +35,7 @@ class RecurringManager(AbstractManager):
     CREDIT_CARD_GATEWAY_CODE = "CREDITCARD"
     CREDIT_CARD_GATEWAYS = ["VISA", "MASTERCARD", "AMEX", "MAESTRO"]
 
-    def __init__(self: "RecurringManager", client: Client):
+    def __init__(self: "RecurringManager", client: Client) -> None:
         """
         Initializes the RecurringManager with a client.
 

--- a/src/multisafepay/api/paths/transactions/transaction_manager.py
+++ b/src/multisafepay/api/paths/transactions/transaction_manager.py
@@ -41,7 +41,7 @@ class TransactionManager(AbstractManager):
     A class representing the TransactionManager.
     """
 
-    def __init__(self: "TransactionManager", client: Client):
+    def __init__(self: "TransactionManager", client: Client) -> None:
         """
         Initialize the CaptureManager with a client.
 

--- a/src/multisafepay/client/client.py
+++ b/src/multisafepay/client/client.py
@@ -45,7 +45,7 @@ class Client:
         is_production: bool,
         http_client: Optional[Session] = None,
         locale: str = "en_US",
-    ):
+    ) -> None:
         """
         Initialize the Client.
 

--- a/src/multisafepay/exception/api.py
+++ b/src/multisafepay/exception/api.py
@@ -21,7 +21,11 @@ class ApiException(Exception):
 
     """
 
-    def __init__(self: "ApiException", message: str, context: dict = {}):
+    def __init__(
+        self: "ApiException",
+        message: str,
+        context: dict = {},
+    ) -> None:
         """
         Initialize the ApiException.
 

--- a/src/multisafepay/sdk.py
+++ b/src/multisafepay/sdk.py
@@ -40,7 +40,7 @@ class Sdk:
         is_production: bool,
         http_client: Optional[Client] = None,
         locale: str = "en_US",
-    ):
+    ) -> None:
         """
         Initialize the SDK with the provided configuration.
 

--- a/src/multisafepay/util/message.py
+++ b/src/multisafepay/util/message.py
@@ -6,7 +6,7 @@
 # See the DISCLAIMER.md file for disclaimer details.
 
 
-from typing import Dict, List
+from typing import Dict, Iterator, List
 
 from pydantic import BaseModel, Field
 
@@ -36,7 +36,7 @@ class MessageList(BaseModel):
 
     __root__: List[Message] = Field(default_factory=list)
 
-    def __iter__(self: "MessageList"):
+    def __iter__(self: "MessageList") -> Iterator[Message]:
         """
         Iterate over the messages in the list.
 
@@ -47,7 +47,7 @@ class MessageList(BaseModel):
         """
         return iter(self.__root__)
 
-    def __getitem__(self: "MessageList", index: int):
+    def __getitem__(self: "MessageList", index: int) -> "Message":
         """
         Get a message by index.
 
@@ -62,7 +62,7 @@ class MessageList(BaseModel):
         """
         return self.__root__[index]
 
-    def __len__(self: "MessageList"):
+    def __len__(self: "MessageList") -> int:
         """
         Get the number of messages in the list.
 

--- a/src/multisafepay/value_object/date.py
+++ b/src/multisafepay/value_object/date.py
@@ -26,7 +26,7 @@ class Date(InmutableModel):
     timestamp: float
     str_date: str
 
-    def __init__(self: "Date", date: str):
+    def __init__(self: "Date", date: str) -> None:
         """
         Initialize a Date object.
 

--- a/tests/multisafepay/integration/api/base/listings/test_integration_listing_pager.py
+++ b/tests/multisafepay/integration/api/base/listings/test_integration_listing_pager.py
@@ -14,7 +14,7 @@ from multisafepay.api.base.listings.cursor import Cursor
 
 
 class MockItem:
-    def __init__(self: "MockItem", value: Any):
+    def __init__(self: "MockItem", value: Any) -> None:
         """
         Initialize a MockItem with a given value.
 

--- a/tests/multisafepay/unit/api/base/listings/test_unit_listing.py
+++ b/tests/multisafepay/unit/api/base/listings/test_unit_listing.py
@@ -11,7 +11,7 @@ from multisafepay.api.base.listings.listing import Listing
 
 
 class MockItem:
-    def __init__(self: "MockItem", value: Any):
+    def __init__(self: "MockItem", value: Any) -> None:
         self.value = value
 
 

--- a/tests/multisafepay/unit/api/base/listings/test_unit_listing_pager.py
+++ b/tests/multisafepay/unit/api/base/listings/test_unit_listing_pager.py
@@ -11,7 +11,7 @@ from multisafepay.api.base.listings.listing_pager import ListingPager
 
 
 class MockItem:
-    def __init__(self: "MockItem", value: Any):
+    def __init__(self: "MockItem", value: Any) -> None:
         """
         Initialize a MockItem with a given value.
 


### PR DESCRIPTION
This pull request introduces type annotations for return values in various methods across the codebase to improve type safety and readability. Additionally, a minor adjustment was made to the `pyproject.toml` configuration.

### Type Annotations for Return Values:
* Added `-> None` return type annotations to `__init__` methods in multiple classes, such as `AbstractManager`, `AuthManager`, `CaptureManager`, and others, ensuring consistency and clarity in constructor definitions. [[1]](diffhunk://#diff-c6126a93fa0dcab436ab259e5cfeb0eea151da306c4fff43ffab5c2498d13436L22-R22) [[2]](diffhunk://#diff-c9d4ace36fe91486564cfa84fab2d3d419405d483009721ca047b92767afe499L25-R25) [[3]](diffhunk://#diff-b083061c0d67eaecd7b07120a63ae672a272ec6a92938ca582804a5bdc866642L29-R29) and more)
* Updated return type annotations for iterator and collection-related methods in `Listing`, `MessageList`, and similar classes, such as `__iter__`, `__getitem__`, and `__len__`, to specify the expected return types (e.g., `-> int`, `-> "Listing"`, `-> "Message"`). [[1]](diffhunk://#diff-62b5e588910b47a262dd56f3532f2992a0bdaafba9e9c02025e8cac0f9583451L56-R56) [[2]](diffhunk://#diff-62b5e588910b47a262dd56f3532f2992a0bdaafba9e9c02025e8cac0f9583451L82-R82) [[3]](diffhunk://#diff-f872be85dc42ddd2b6938eb11fb61f3e1e441c944af3cb0ec42a826f6189e728L39-R39) [[4]](diffhunk://#diff-f872be85dc42ddd2b6938eb11fb61f3e1e441c944af3cb0ec42a826f6189e728L65-R65)

### Configuration Adjustments:
* Removed `ANN204` from the `ignore` list in the `pyproject.toml` file, likely to enforce stricter adherence to type annotation rules.