### PR TITLE
PTHMINT-47: Fix ruff ANN401

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ extend-safe-fixes = [
     "D415", # docstrings should end with a period, question mark, or exclamation point
 ]
 ignore = [
-    "ANN401",
     "ARG002",
     "B006",
     "B904",

--- a/src/multisafepay/api/base/response/api_response.py
+++ b/src/multisafepay/api/base/response/api_response.py
@@ -6,7 +6,7 @@
 # See the DISCLAIMER.md file for disclaimer details.
 
 
-from typing import Any, Optional
+from typing import Optional, Union
 
 from multisafepay.api.base.listings.pager import Pager
 from multisafepay.model.extra_model import ExtraModel
@@ -65,7 +65,7 @@ class ApiResponse(ExtraModel):
             raw=json_data.__str__(),
         )
 
-    def get_body_data(self: "ApiResponse") -> Optional[Any]:
+    def get_body_data(self: "ApiResponse") -> Optional[Union[dict, list]]:
         """
         Get the data from the body of the response.
 

--- a/src/multisafepay/api/base/response/custom_api_response.py
+++ b/src/multisafepay/api/base/response/custom_api_response.py
@@ -5,7 +5,7 @@
 
 # See the DISCLAIMER.md file for disclaimer details.
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from multisafepay.api.base.response.api_response import ApiResponse
 
@@ -20,11 +20,11 @@ class CustomApiResponse(ApiResponse):
 
     """
 
-    data: Optional[Any]
+    data: Optional[Union[dict, list]]
 
     def __init__(
         self: "CustomApiResponse",
-        data: Optional[Any],
+        data: Optional[Union[dict, list]],
         **kwargs: Dict[str, Any],
     ) -> None:
         """
@@ -41,7 +41,7 @@ class CustomApiResponse(ApiResponse):
         for key, value in kwargs.items():
             setattr(self, key, value)
 
-    def get_data(self: "CustomApiResponse") -> Optional[Any]:
+    def get_data(self: "CustomApiResponse") -> Optional[Union[dict, list]]:
         """
         Get the data contained in the response.
 

--- a/src/multisafepay/exception/api.py
+++ b/src/multisafepay/exception/api.py
@@ -7,7 +7,7 @@
 
 
 import json
-from typing import Any
+from typing import Dict, List, Optional, Union
 
 
 class ApiException(Exception):
@@ -115,7 +115,10 @@ class ApiException(Exception):
             lines.append(f"{context_name}: {debug_value}")
         return lines
 
-    def get_context_value(self: "ApiException", name: str) -> Any:
+    def get_context_value(
+        self: "ApiException",
+        name: str,
+    ) -> Optional[Union[str, int, float, bool, Dict, List]]:
         """
         Get a specific context value by name.
 
@@ -125,7 +128,8 @@ class ApiException(Exception):
 
         Returns
         -------
-        The value associated with the given name, or None if the name is not found.
+        Optional[Union[str, int, float, bool, Dict, List]]: The value associated with the given name,
+            or None if the name is not found.
 
         """
         return self.context.get(name)

--- a/src/multisafepay/util/dict_utils.py
+++ b/src/multisafepay/util/dict_utils.py
@@ -5,7 +5,7 @@
 
 # See the DISCLAIMER.md file for disclaimer details.
 
-from typing import Any, Optional
+from typing import Optional
 
 
 def merge_recursive(dict1: dict, dict2: dict) -> dict:
@@ -66,7 +66,7 @@ def remove_null_recursive(input_data: dict) -> dict:
 
     """
 
-    def process_value(value: Any) -> Optional[Any]:
+    def process_value(value: object) -> Optional[object]:
         if isinstance(value, dict):
             processed_dict = remove_null_recursive(value)
             return processed_dict if processed_dict else None
@@ -85,7 +85,7 @@ def remove_null_recursive(input_data: dict) -> dict:
     }
 
 
-def dict_empty(value: Any) -> bool:
+def dict_empty(value: object) -> bool:
     """
     Check if the given value is an empty dictionary.
 

--- a/src/multisafepay/util/total_amount.py
+++ b/src/multisafepay/util/total_amount.py
@@ -7,7 +7,6 @@
 
 
 import json
-from typing import Any
 
 from multisafepay.exception.invalid_total_amount import (
     InvalidTotalAmountException,
@@ -74,7 +73,7 @@ def __calculate_totals(data: dict) -> float:
 def __get_tax_rate_by_item(
     item: dict,
     data: dict,
-) -> Any:
+) -> object:
     """
     Get the tax rate for a specific item in the shopping cart.
 
@@ -85,7 +84,7 @@ def __get_tax_rate_by_item(
 
     Returns
     -------
-    int | List[int | Any] | Any: The tax rate for the item, or 0 if no tax rate is found.
+    object: The tax rate for the item, or 0 if no tax rate is found.
 
     """
     if "tax_table_selector" not in item or not item["tax_table_selector"]:

--- a/tests/multisafepay/integration/api/base/listings/test_integration_listing_pager.py
+++ b/tests/multisafepay/integration/api/base/listings/test_integration_listing_pager.py
@@ -6,15 +6,13 @@
 # See the DISCLAIMER.md file for disclaimer details.
 
 
-from typing import Any
-
 from multisafepay.api.base.listings.listing_pager import ListingPager
 from multisafepay.api.base.listings.pager import Pager
 from multisafepay.api.base.listings.cursor import Cursor
 
 
 class MockItem:
-    def __init__(self: "MockItem", value: Any) -> None:
+    def __init__(self: "MockItem", value: object) -> None:
         """
         Initialize a MockItem with a given value.
 

--- a/tests/multisafepay/unit/api/base/listings/test_unit_listing.py
+++ b/tests/multisafepay/unit/api/base/listings/test_unit_listing.py
@@ -5,13 +5,12 @@
 
 # See the DISCLAIMER.md file for disclaimer details.
 
-from typing import Any
 
 from multisafepay.api.base.listings.listing import Listing
 
 
 class MockItem:
-    def __init__(self: "MockItem", value: Any) -> None:
+    def __init__(self: "MockItem", value: object) -> None:
         self.value = value
 
 

--- a/tests/multisafepay/unit/api/base/listings/test_unit_listing_pager.py
+++ b/tests/multisafepay/unit/api/base/listings/test_unit_listing_pager.py
@@ -5,13 +5,12 @@
 
 # See the DISCLAIMER.md file for disclaimer details.
 
-from typing import Any
 
 from multisafepay.api.base.listings.listing_pager import ListingPager
 
 
 class MockItem:
-    def __init__(self: "MockItem", value: Any) -> None:
+    def __init__(self: "MockItem", value: object) -> None:
         """
         Initialize a MockItem with a given value.
 


### PR DESCRIPTION
This pull request refines type annotations across multiple files to improve type safety and consistency in the codebase. The changes primarily involve replacing the use of `Any` with more specific types such as `Union`, `object`, or structured types like `dict` and `list`. Additionally, some unused imports of `Any` were removed to clean up the code.

### Type Annotation Improvements:

* **API Response Enhancements**:
  - Updated `get_body_data` in `src/multisafepay/api/base/response/api_response.py` to return `Optional[Union[dict, list]]` instead of `Optional[Any]` for better specificity.
  - Modified `data` and related methods in `CustomApiResponse` to use `Optional[Union[dict, list]]` instead of `Optional[Any]`. [[1]](diffhunk://#diff-cc24ecd65384ecec7aebfe1a4fbedd71719b1653ea0448845cb8627689d39894L23-R27) [[2]](diffhunk://#diff-cc24ecd65384ecec7aebfe1a4fbedd71719b1653ea0448845cb8627689d39894L44-R44)

* **Exception Handling**:
  - Updated `get_context_value` in `src/multisafepay/exception/api.py` to return `Optional[Union[str, int, float, bool, Dict, List]]` instead of `Any`. [[1]](diffhunk://#diff-40e60d68562553550e2e81b9501f69fb80dc48b7e3ebfb204dd9c5070181ead8L118-R121) [[2]](diffhunk://#diff-40e60d68562553550e2e81b9501f69fb80dc48b7e3ebfb204dd9c5070181ead8L128-R132)

* **Utility Functions**:
  - Replaced `Any` with `object` in utility functions such as `process_value` and `dict_empty` in `src/multisafepay/util/dict_utils.py`. [[1]](diffhunk://#diff-4c77e491005d1fd425fac10da9f313be7204727536d4915432abbdb5ceefc245L69-R69) [[2]](diffhunk://#diff-4c77e491005d1fd425fac10da9f313be7204727536d4915432abbdb5ceefc245L88-R88)
  - Updated `__get_tax_rate_by_item` in `src/multisafepay/util/total_amount.py` to return `object` instead of `Any`. [[1]](diffhunk://#diff-193aafed45f34e7dc5717a812cf4eebbc2c223e6350e91c014513e6a74cf8b8bL77-R76) [[2]](diffhunk://#diff-193aafed45f34e7dc5717a812cf4eebbc2c223e6350e91c014513e6a74cf8b8bL88-R87)

### Code Cleanup:

* Removed unused `Any` imports from several files, including `src/multisafepay/util/dict_utils.py`, `src/multisafepay/util/total_amount.py`, and test files. [[1]](diffhunk://#diff-4c77e491005d1fd425fac10da9f313be7204727536d4915432abbdb5ceefc245L8-R8) [[2]](diffhunk://#diff-193aafed45f34e7dc5717a812cf4eebbc2c223e6350e91c014513e6a74cf8b8bL10) [[3]](diffhunk://#diff-96b2f4703b2ba59b67364614439275b855f0ca61e0978d823b38f1923dd7f841L9-R15) [[4]](diffhunk://#diff-0cbb9d11331c35664b1076339c49d1740db95888214941d7785558a5b041b4d3L8-R13) [[5]](diffhunk://#diff-2b1a3e8da9d772d8f377f2115517ecc625be68536fbaab8920206857da9be8aeL8-R13)

### Configuration Update:

* Removed `ANN401` from the `ignore` list in `pyproject.toml`, likely to enforce stricter adherence to type annotation rules.