### PR TITLE
PTHMINT-48: Fix ruff ARG002

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ extend-safe-fixes = [
     "D415", # docstrings should end with a period, question mark, or exclamation point
 ]
 ignore = [
-    "ARG002",
     "B006",
     "B904",
     "BLE001",

--- a/src/multisafepay/api/paths/recurring/recurring_manager.py
+++ b/src/multisafepay/api/paths/recurring/recurring_manager.py
@@ -50,7 +50,6 @@ class RecurringManager(AbstractManager):
     def get_list(
         self: "RecurringManager",
         reference: str,
-        force_api_call: bool = False,
     ) -> CustomApiResponse:
         """
         Retrieves a list of recurring tokens for a given customer reference.


### PR DESCRIPTION
This pull request includes minor updates to configuration and code cleanup. The changes focus on removing unnecessary entries and parameters to simplify the codebase.

### Configuration updates:
* Removed the `ARG002` entry from the `ignore` list in `pyproject.toml`, likely indicating that this rule is no longer ignored during linting.

### Code cleanup:
* Removed the `force_api_call` parameter from the `get_list` method in `RecurringManager` as it was unused, simplifying the method signature.