### PR TITLE
PTHMINT-50: Fix ruff B904

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,6 @@ extend-safe-fixes = [
     "D415", # docstrings should end with a period, question mark, or exclamation point
 ]
 ignore = [
-    "B904",
     "BLE001",
     "D100",
     "D101",

--- a/src/multisafepay/api/shared/cart/cart_item.py
+++ b/src/multisafepay/api/shared/cart/cart_item.py
@@ -280,10 +280,10 @@ class CartItem(ApiModel):
 
         try:
             self.tax_table_selector = str(tax_rate_percentage / 100)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError) as e:
             raise InvalidArgumentException(
                 "Tax rate percentage cannot be converted to a string.",
-            )
+            ) from e
 
         return self
 
@@ -316,10 +316,10 @@ class CartItem(ApiModel):
 
         try:
             self.tax_table_selector = str(tax_rate)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError) as e:
             raise InvalidArgumentException(
                 "Tax rate cannot be converted to a string.",
-            )
+            ) from e
 
         return self
 

--- a/src/multisafepay/client/client.py
+++ b/src/multisafepay/client/client.py
@@ -246,7 +246,7 @@ class Client:
             response.raise_for_status()
         except RequestException as e:
             if 500 <= response.status_code < 600:
-                raise ApiException(f"Request failed: {e}")
+                raise ApiException(f"Request failed: {e}") from e
 
         context = context or {}
         context.update(

--- a/src/multisafepay/util/webhook.py
+++ b/src/multisafepay/util/webhook.py
@@ -60,10 +60,10 @@ class Webhook:
                 transaction_json,
                 separators=(",", ":"),
             )
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as e:
             raise InvalidArgumentException(
                 "Request must be a valid JSON string",
-            )
+            ) from e
 
         if validation_time_in_seconds < 0:
             raise InvalidArgumentException(

--- a/src/multisafepay/value_object/date.py
+++ b/src/multisafepay/value_object/date.py
@@ -45,10 +45,10 @@ class Date(InmutableModel):
             else:
                 timestamp = datetime.strptime(date, "%Y-%m-%d").timestamp()
             super().__init__(timestamp=timestamp, str_date=date)
-        except ValueError:
+        except ValueError as e:
             raise InvalidArgumentException(
                 f'Value "{date}" is an invalid date format',
-            )
+            ) from e
 
     def get(self: "Date", date_format: str = "%Y-%m-%d") -> str:
         """


### PR DESCRIPTION
This pull request introduces several changes to improve error handling by adding exception chaining (`from e`) across multiple methods. Additionally, it includes a minor update to the `pyproject.toml` configuration. Below is a summary of the most important changes:

### Improved error handling with exception chaining:

* `src/multisafepay/api/shared/cart/cart_item.py`:
  - Updated the `add_tax_rate_percentage` method to include exception chaining when raising `InvalidArgumentException` for invalid tax rate percentages.
  - Updated the `add_tax_rate` method to include exception chaining when raising `InvalidArgumentException` for invalid tax rates.

* `src/multisafepay/client/client.py`:
  - Modified the `_create_request` method to add exception chaining when raising `ApiException` for server errors (HTTP 5xx).

* `src/multisafepay/util/webhook.py`:
  - Enhanced the `validate` method to include exception chaining when raising `InvalidArgumentException` for invalid JSON strings.

* `src/multisafepay/value_object/date.py`:
  - Updated the `__init__` method of the `Date` class to include exception chaining when raising `InvalidArgumentException` for invalid date formats.

### Configuration updates:

* `pyproject.toml`:
  - Removed the `B904` error code from the `ignore` list in the configuration file.