### PR TITLE
PTHMINT-75: Remove unsupported attribute in docs (delivery)

### DIFF
--- a/src/multisafepay/api/shared/delivery.py
+++ b/src/multisafepay/api/shared/delivery.py
@@ -31,9 +31,6 @@ class Delivery(ApiModel):
     country (Optional[str]): The country code.
     phone (Optional[str]): The phone number.
     email (Optional[str]): The email address.
-    street_name (Optional[str]): The street name.
-    street_name_additional (Optional[str]): Additional street name information.
-    house_number_suffix (Optional[str]): The house number suffix.
 
     """
 
@@ -48,10 +45,6 @@ class Delivery(ApiModel):
     country: Optional[str]
     phone: Optional[str]
     email: Optional[str]
-    street_name: Optional[str]
-    street_name_additional: Optional[str]
-    house_number_suffix: Optional[str]
-    country_name: Optional[str]
 
     def add_first_name(
         self: "Delivery",
@@ -251,82 +244,6 @@ class Delivery(ApiModel):
         if isinstance(email, str):
             email = EmailAddress(email_address=email)
         self.email = email.get()
-        return self
-
-    def add_street_name(
-        self: "Delivery",
-        street_name: Optional[str],
-    ) -> "Delivery":
-        """
-        Add the street name to the delivery information.
-
-        Parameters
-        ----------
-        street_name (Optional[str]): The street name to add.
-
-        Returns
-        -------
-        Delivery: The updated Delivery instance.
-
-        """
-        self.street_name = street_name
-        return self
-
-    def add_street_name_additional(
-        self: "Delivery",
-        street_name_additional: Optional[str],
-    ) -> "Delivery":
-        """
-        Add additional street name information to the delivery information.
-
-        Parameters
-        ----------
-        street_name_additional (Optional[str]): The additional street name information to add.
-
-        Returns
-        -------
-        Delivery: The updated Delivery instance.
-
-        """
-        self.street_name_additional = street_name_additional
-        return self
-
-    def add_house_number_suffix(
-        self: "Delivery",
-        house_number_suffix: Optional[str],
-    ) -> "Delivery":
-        """
-        Add the house number suffix to the delivery information.
-
-        Parameters
-        ----------
-        house_number_suffix (Optional[str]): The house number suffix to add.
-
-        Returns
-        -------
-        Delivery: The updated Delivery instance.
-
-        """
-        self.house_number_suffix = house_number_suffix
-        return self
-
-    def add_country_name(
-        self: "Delivery",
-        country_name: Optional[str],
-    ) -> "Delivery":
-        """
-        Add the country name to the delivery information.
-
-        Parameters
-        ----------
-        country_name (Optional[str]): The country name to add.
-
-        Returns
-        -------
-        Delivery: The updated Delivery instance.
-
-        """
-        self.country_name = country_name
         return self
 
     @staticmethod

--- a/tests/multisafepay/unit/api/shared/test_unit_delivery.py
+++ b/tests/multisafepay/unit/api/shared/test_unit_delivery.py
@@ -25,9 +25,6 @@ def test_initializes_with_valid_values():
         country="USA",
         phone="555-1234",
         email="example@multisafepay.com",
-        street_name="Main St",
-        street_name_additional="Near the park",
-        house_number_suffix="A",
     )
     assert delivery.first_name == "John"
     assert delivery.last_name == "Doe"
@@ -40,9 +37,6 @@ def test_initializes_with_valid_values():
     assert delivery.country == "USA"
     assert delivery.phone == "555-1234"
     assert delivery.email == "example@multisafepay.com"
-    assert delivery.street_name == "Main St"
-    assert delivery.street_name_additional == "Near the park"
-    assert delivery.house_number_suffix == "A"
 
 
 def test_initializes_with_default_values():
@@ -61,9 +55,6 @@ def test_initializes_with_default_values():
     assert delivery.country is None
     assert delivery.phone is None
     assert delivery.email is None
-    assert delivery.street_name is None
-    assert delivery.street_name_additional is None
-    assert delivery.house_number_suffix is None
 
 
 def test_adds_first_name():
@@ -130,38 +121,6 @@ def test_adds_state():
     assert delivery.state == "CA"
 
 
-def test_adds_street_name():
-    """
-    Test that a street name is added to the Delivery instance.
-    """
-    delivery = Delivery().add_street_name("Main St")
-    assert delivery.street_name == "Main St"
-
-
-def test_adds_street_name_as_string():
-    """
-    Test that a street name as a string is added to the Delivery instance.
-    """
-    delivery = Delivery().add_street_name("Main St")
-    assert delivery.street_name == "Main St"
-
-
-def test_adds_street_name_additional():
-    """
-    Test that additional street name information is added to the Delivery instance.
-    """
-    delivery = Delivery().add_street_name_additional("Near the park")
-    assert delivery.street_name_additional == "Near the park"
-
-
-def test_adds_house_number_suffix():
-    """
-    Test that a house number suffix is added to the Delivery instance.
-    """
-    delivery = Delivery().add_house_number_suffix("A")
-    assert delivery.house_number_suffix == "A"
-
-
 def test_creates_from_dict_with_all_fields():
     """
     Test that a Delivery instance is created from a dictionary with all fields.
@@ -178,9 +137,6 @@ def test_creates_from_dict_with_all_fields():
         "country": "USA",
         "phone": "555-1234",
         "email": "john.doe@example.com",
-        "street_name": "Main St",
-        "street_name_additional": "Near the park",
-        "house_number_suffix": "A",
     }
     delivery = Delivery.from_dict(data)
     assert delivery.first_name == "John"
@@ -194,9 +150,6 @@ def test_creates_from_dict_with_all_fields():
     assert delivery.country == "USA"
     assert delivery.phone == "555-1234"
     assert delivery.email == "john.doe@example.com"
-    assert delivery.street_name == "Main St"
-    assert delivery.street_name_additional == "Near the park"
-    assert delivery.house_number_suffix == "A"
 
 
 def test_creates_from_empty_dict():
@@ -216,9 +169,6 @@ def test_creates_from_empty_dict():
     assert delivery.country is None
     assert delivery.phone is None
     assert delivery.email is None
-    assert delivery.street_name is None
-    assert delivery.street_name_additional is None
-    assert delivery.house_number_suffix is None
 
 
 def test_creates_from_none():


### PR DESCRIPTION
This pull request removes several fields and their associated methods from the `Delivery` class in the `src/multisafepay/api/shared/delivery.py` file, along with corresponding test cases in the `tests/multisafepay/unit/api/shared/test_unit_delivery.py` file. The removed fields include `street_name`, `street_name_additional`, `house_number_suffix`, and `country_name`.

### Changes to the `Delivery` class:

* Removed the fields `street_name`, `street_name_additional`, `house_number_suffix`, and `country_name` from the `Delivery` class definition. [[1]](diffhunk://#diff-bd7459d02efb7b2a148be232b0b6833d5845b10a327fbcefc45ab274e6385092L34-L36) [[2]](diffhunk://#diff-bd7459d02efb7b2a148be232b0b6833d5845b10a327fbcefc45ab274e6385092L51-L54)
* Deleted methods for adding these fields (`add_street_name`, `add_street_name_additional`, `add_house_number_suffix`, and `add_country_name`).

### Changes to test cases:

* Updated the `test_initializes_with_valid_values` and `test_initializes_with_default_values` tests to remove assertions related to the deleted fields. [[1]](diffhunk://#diff-d0f981682d5a7bfcb9e75ddc50f3f51467646cd5577ad2ac081e9cfe557fb6f1L28-L30) [[2]](diffhunk://#diff-d0f981682d5a7bfcb9e75ddc50f3f51467646cd5577ad2ac081e9cfe557fb6f1L43-L45) [[3]](diffhunk://#diff-d0f981682d5a7bfcb9e75ddc50f3f51467646cd5577ad2ac081e9cfe557fb6f1L64-L66)
* Removed specific test cases for the deleted fields, such as `test_adds_street_name`, `test_adds_street_name_additional`, and `test_adds_house_number_suffix`.
* Updated the `test_creates_from_dict_with_all_fields` and `test_creates_from_empty_dict` tests to remove references to the deleted fields. [[1]](diffhunk://#diff-d0f981682d5a7bfcb9e75ddc50f3f51467646cd5577ad2ac081e9cfe557fb6f1L181-L183) [[2]](diffhunk://#diff-d0f981682d5a7bfcb9e75ddc50f3f51467646cd5577ad2ac081e9cfe557fb6f1L197-L199) [[3]](diffhunk://#diff-d0f981682d5a7bfcb9e75ddc50f3f51467646cd5577ad2ac081e9cfe557fb6f1L219-L221)