### PR TITLE
PTHMINT-130: Update SDK version handling and tests to include version…

### DIFF
--- a/src/multisafepay/__init__.py
+++ b/src/multisafepay/__init__.py
@@ -1,7 +1,10 @@
 """MultiSafepay Python SDK main package."""
 
+__version__ = "3.0.0"
+
 from multisafepay.sdk import Sdk
 
 __all__ = [
     "Sdk",
+    "__version__",
 ]

--- a/src/multisafepay/util/version.py
+++ b/src/multisafepay/util/version.py
@@ -9,6 +9,7 @@
 
 from typing import Optional
 
+from multisafepay import __version__
 from pydantic import BaseModel
 
 
@@ -59,4 +60,4 @@ class Version(BaseModel):
         MissingPluginVersionException: If the plugin version is "unknown".
 
         """
-        return f"Plugin {self.plugin_version}"
+        return f"Plugin {self.plugin_version}; Python-Sdk {__version__}"

--- a/tests/multisafepay/unit/util/test_unit_version.py
+++ b/tests/multisafepay/unit/util/test_unit_version.py
@@ -57,7 +57,7 @@ def test_version_get_plugin_version():
 def test_version_get_version():
     """Test the get_version method of the Version object."""
     version = Version(plugin_version="1.0.1")
-    assert version.get_version() == "Plugin 1.0.1"
+    assert version.get_version() == "Plugin 1.0.1; Python-Sdk 3.0.0"
 
 
 def test_version_set_plugin_version():


### PR DESCRIPTION
This pull request updates the way the SDK version is tracked and reported in the MultiSafepay Python SDK. The main change is to include the SDK version in the version string returned by `Version.get_version()`. This ensures that both the plugin and SDK versions are visible, improving transparency for debugging and support.

**Versioning improvements:**

* Added a `__version__` variable set to `"3.0.0"` in `src/multisafepay/__init__.py` and included it in the module's public API.
* Updated `src/multisafepay/util/version.py` to import `__version__` and include it in the string returned by `Version.get_version()`. [[1]](diffhunk://#diff-83bf0d4d32fe0f5bdcb9bbfb22e265b86bc10b982885c8b1420aceab0d50da55R12) [[2]](diffhunk://#diff-83bf0d4d32fe0f5bdcb9bbfb22e265b86bc10b982885c8b1420aceab0d50da55L62-R63)

**Testing updates:**

* Modified the unit test in `tests/multisafepay/unit/util/test_unit_version.py` to expect the new version string format including the SDK version.… information