### PR TITLE
PTHMINT-131: Add error handling for transport exceptions and server e…

### DIFF
--- a/src/multisafepay/client/client.py
+++ b/src/multisafepay/client/client.py
@@ -344,6 +344,7 @@ class Client:
             "Content-Type": "application/json",
         }
 
+        response = None
         try:
             response = self.transport.request(
                 method=method,
@@ -354,7 +355,8 @@ class Client:
             response.raise_for_status()
         except Exception as e:
             if (
-                hasattr(response, "status_code")
+                response is not None
+                and hasattr(response, "status_code")
                 and 500 <= response.status_code < 600
             ):
                 raise ApiException(f"Request failed: {e}") from e

--- a/tests/multisafepay/unit/client/test_unit_client.py
+++ b/tests/multisafepay/unit/client/test_unit_client.py
@@ -14,6 +14,7 @@ from multisafepay.client.client import Client
 from multisafepay.client.credential_resolver import (
     ScopedCredentialResolver,
 )
+from multisafepay.exception.api import ApiException
 from multisafepay.transport import RequestsTransport
 
 requests = pytest.importorskip("requests")
@@ -52,6 +53,32 @@ class _CaptureTransport:
     def request(self: "_CaptureTransport", **kwargs: dict) -> _FakeResponse:
         self.headers = kwargs.get("headers", {})
         return _FakeResponse()
+
+
+class _FailingTransport:
+    """Transport stub that fails before returning a response."""
+
+    @staticmethod
+    def request(**kwargs: dict) -> _FakeResponse:
+        raise RuntimeError("network unavailable")
+
+
+class _ServerErrorResponse(_FakeResponse):
+    """Response stub that raises for a server error."""
+
+    status_code = 500
+
+    @staticmethod
+    def raise_for_status() -> None:
+        raise RuntimeError("server error")
+
+
+class _ServerErrorTransport:
+    """Transport stub that returns a server error response."""
+
+    @staticmethod
+    def request(**kwargs: dict) -> _ServerErrorResponse:
+        return _ServerErrorResponse()
 
 
 def _build_resolver_client(
@@ -326,6 +353,30 @@ def test_create_delete_request_sends_authorization_header() -> None:
     )
     client.create_delete_request("json/recurring/1")
     assert transport.headers["Authorization"] == "Bearer test_key"
+
+
+def test_request_exception_without_response_is_reraised() -> None:
+    """Reraise transport exceptions when no response exists."""
+    client = Client(
+        api_key="test_key",
+        is_production=False,
+        transport=_FailingTransport(),
+    )
+
+    with pytest.raises(RuntimeError, match="network unavailable"):
+        client.create_get_request("json/orders")
+
+
+def test_server_error_response_raises_api_exception() -> None:
+    """Wrap server error responses in ApiException."""
+    client = Client(
+        api_key="test_key",
+        is_production=False,
+        transport=_ServerErrorTransport(),
+    )
+
+    with pytest.raises(ApiException, match="Request failed: server error"):
+        client.create_get_request("json/orders")
 
 
 def test_resolve_api_key_uses_credential_resolver() -> None:

--- a/tests/multisafepay/unit/client/test_unit_client.py
+++ b/tests/multisafepay/unit/client/test_unit_client.py
@@ -59,7 +59,8 @@ class _FailingTransport:
     """Transport stub that fails before returning a response."""
 
     @staticmethod
-    def request(**kwargs: dict) -> _FakeResponse:
+    def request(**_kwargs: dict) -> _FakeResponse:
+        """Simulate a request that fails with a transport error."""
         raise RuntimeError("network unavailable")
 
 
@@ -70,6 +71,7 @@ class _ServerErrorResponse(_FakeResponse):
 
     @staticmethod
     def raise_for_status() -> None:
+        """Simulate a server error status raise."""
         raise RuntimeError("server error")
 
 
@@ -77,7 +79,8 @@ class _ServerErrorTransport:
     """Transport stub that returns a server error response."""
 
     @staticmethod
-    def request(**kwargs: dict) -> _ServerErrorResponse:
+    def request(**_kwargs: dict) -> _ServerErrorResponse:
+        """Simulate a request that returns a server error response."""
         return _ServerErrorResponse()
 
 


### PR DESCRIPTION
This pull request improves error handling in the `Client` class and adds comprehensive unit tests to ensure correct behavior when network errors or server errors occur. The main changes focus on making exception handling more robust and well-tested.

**Error handling improvements:**

* Updated `_create_request` in `client.py` to initialize `response` to `None` and check for `response is not None` before accessing its attributes, preventing errors when the transport fails before returning a response. [[1]](diffhunk://#diff-0a66a3522e7c56b4cf79424783768b76873b1ee763ae81f77d7fe5b7d4d888b1R347) [[2]](diffhunk://#diff-0a66a3522e7c56b4cf79424783768b76873b1ee763ae81f77d7fe5b7d4d888b1L357-R359)

**Testing enhancements:**

* Added new test stubs (`_FailingTransport`, `_ServerErrorTransport`, `_ServerErrorResponse`) to simulate network failures and server errors, enabling more thorough testing of error handling logic in the `Client`.
* Added a unit test to verify that exceptions raised by the transport before a response exists are reraised as-is.
* Added a unit test to ensure that server error responses (HTTP 5xx) are wrapped and raised as an `ApiException`.
* Imported `ApiException` in the test module to support the new tests.…rrors in Client