### PR TITLE
PTHMINT-133: Ensure fixed-point formatting in CartItem.add_tax_rate_p…

### DIFF
--- a/src/multisafepay/api/shared/cart/cart_item.py
+++ b/src/multisafepay/api/shared/cart/cart_item.py
@@ -297,7 +297,7 @@ class CartItem(ApiModel):
             # Use Decimal for precise division
             percentage_decimal = Decimal(str(tax_rate_percentage))
             rating = percentage_decimal / Decimal("100")
-            self.tax_table_selector = str(rating)
+            self.tax_table_selector = format(rating, "f")
         except (ValueError, TypeError) as e:
             raise InvalidArgumentException(
                 "Tax rate percentage cannot be converted to a string.",

--- a/tests/multisafepay/unit/api/shared/cart/test_unit_cart_item.py
+++ b/tests/multisafepay/unit/api/shared/cart/test_unit_cart_item.py
@@ -189,15 +189,37 @@ def test_add_tax_rate_percentage():
     assert item.tax_table_selector == "0.21"
 
 
-def test_add_tax_rate_percentage():
+def test_add_tax_rate_percentage_zero_int():
     """Test that a 0 tax rate percentage is correctly set as the tax table selector in a CartItem."""
     item = CartItem()
     item.add_tax_rate_percentage(0)
-    assert item.tax_table_selector == "0.0"
+    assert item.tax_table_selector == "0"
 
 
-def test_add_tax_rate_percentage():
+def test_add_tax_rate_percentage_zero():
     """Test that a 0.0 tax rate percentage is correctly set as the tax table selector in a CartItem."""
     item = CartItem()
     item.add_tax_rate_percentage(0.0)
     assert item.tax_table_selector == "0.0"
+
+
+def test_add_tax_rate_percentage_prevents_scientific_notation_zero():
+    """Test that a quantized Decimal zero does not produce scientific notation ('0E-10') in tax_table_selector."""
+    from decimal import Decimal
+
+    item = CartItem()
+    scientific_zero = Decimal("0").quantize(Decimal("0.0000000001"))
+    item.add_tax_rate_percentage(scientific_zero)
+    assert "E" not in item.tax_table_selector
+    assert float(item.tax_table_selector) == 0.0
+
+
+def test_add_tax_rate_percentage_prevents_scientific_notation_small_decimal():
+    """Test that small Decimal numbers with negative exponents do not produce scientific notation in tax_table_selector."""
+    from decimal import Decimal
+
+    item = CartItem()
+    small_decimal = Decimal("1E-8")
+    item.add_tax_rate_percentage(small_decimal)
+    assert "E" not in item.tax_table_selector
+    assert item.tax_table_selector == "0.0000000001"


### PR DESCRIPTION
This PR fixes an issue in CartItem.add_tax_rate_percentage where converting the calculated tax rate ratio to a string via str(rating) could produce scientific exponential notation (such as '0E-10' or '1E-8') when handling Decimal objects with negative exponents.

When '0E-10' is sent in the API payload, it fails to match zero-tax rule keys (e.g. '0') in checkout_options.tax_tables.alternate, causing shopping cart validation errors.